### PR TITLE
Extend mailbox to multiple steps

### DIFF
--- a/nesProject/central_unit.c
+++ b/nesProject/central_unit.c
@@ -115,18 +115,19 @@ void processGateMessage(unsigned char* message, int payloadSize)
 
 void processMboxMessage(unsigned char* message, int payloadSize)
 {
-    unsigned char cmd = message[0];
-
-    if(cmd == MBOX_EMPTY)
-    {
-        printf("Mailbox is empty\n");
-        leds_off(LEDS_BLUE);
-    }
-    else if(cmd == MBOX_FULL)
-    {
-        printf("Mailbox is full\n");
+    unsigned char mboxLoad = message[0];
+    
+    if(mboxLoad == 0)
+        printf("Mailbox is empty.\n");
+    else if(mboxLoad == MBOX_MAX_LOAD)
+        printf("Mailbox is full!\n");
+    else
+        printf("Mailbox is at %d0%% load\n", mboxLoad);
+    
+    if(mboxLoad >= MBOX_NOTIFICATION_LOAD)
         leds_on(LEDS_BLUE);
-    }
+    else
+        leds_off(LEDS_BLUE);
 }
 
 void helpText()

--- a/nesProject/commons/constants.h
+++ b/nesProject/commons/constants.h
@@ -23,8 +23,8 @@
 #define ALARM_LED_PERIOD 2
 
 //Mailbox
-#define MBOX_EMPTY 1
-#define MBOX_FULL 2
+#define MBOX_MAX_LOAD 10
+#define MBOX_NOTIFICATION_LOAD 7
 
 //Auto-opening
 #define AUTO_OPENING_LED_PERIOD 2

--- a/nesProject/mailbox_node.c
+++ b/nesProject/mailbox_node.c
@@ -12,7 +12,7 @@ AUTOSTART_PROCESSES(&mbox_node_main);
 
 PROCESS_THREAD(mbox_node_main, ev, data)
 {
-	static int isFull = 0;
+	static char mboxLoad = 0;
 
 	PROCESS_BEGIN();
 	
@@ -22,20 +22,17 @@ PROCESS_THREAD(mbox_node_main, ev, data)
 	while(1)
 	{
 		PROCESS_WAIT_EVENT_UNTIL(ev == sensors_event && data == &button_sensor);
-		if(isFull)
-		{
-			isFull = 0;
-			printf("Mailbox is empty\n");
-			unsigned char command = MBOX_EMPTY;
-			sendFromMboxToCentralUnit(&command, 1);
-		}
+		mboxLoad = (mboxLoad + 1) % (MBOX_MAX_LOAD + 1);
+		
+		if(mboxLoad == 0)
+			printf("Mailbox is empty.\n");
+		else if(mboxLoad == MBOX_MAX_LOAD)
+			printf("Mailbox is full!\n");
 		else
-		{
-			isFull = 1;
-			printf("Mailbox is full\n");
-			unsigned char command = MBOX_FULL;
-			sendFromMboxToCentralUnit(&command, 1);
-		}	
+			printf("Mailbox is at %d0%% load\n", mboxLoad);
+		
+		unsigned char command = mboxLoad;
+		sendFromMboxToCentralUnit(&command, 1);
 	}
 	PROCESS_END();
 }


### PR DESCRIPTION
Mailbox has a circular counter, not track multiple levels of load.
Central unit prints all updates to screen, and notifies with blue led when load is more than a configured amount.